### PR TITLE
Fix links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ with open source software (OSS).
 
 This dataset was prepared by Eugenia Lostri, Georgia Wood, and Megha Jain from the Center for Strategic and International Studies (CSIS). 
 
-You can explore summary visualizations of the dataset [here](https://reimagined-fortnight-b321a25c.pages.github.io/) or perform your own analyses by creating a [Codespace](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=579221324). The raw dataset is available [here](https://github.com/github/government-open-source-policies-test/blob/main/data/OSS.Dataset.-.December.2022.v3.csv). The dataset can also be accessed on the [CSIS website](#holder).
+You can explore summary visualizations of the dataset [here](https://reimagined-fortnight-b321a25c.pages.github.io/) or perform your own analyses by creating a [Codespace](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=579221324). The raw dataset is available [here](https://github.com/github/government-open-source-policies/blob/main/data/OSS.Dataset.-.December.2022.v3.csv). The dataset can also be accessed on the [CSIS website](#holder).
 
 Comments, corrections and new data are welcome. Please review our [Contribution page](./CONTRIBUTING.md).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -202,7 +202,7 @@ SOFTWARE.
 -->
 <section id="dataset" class="level2">
 <h2 class="anchored" data-anchor-id="dataset">Dataset</h2>
-<p>Explore the <a href="https://github.com/github/government-open-source-policies-test/blob/main/data/OSS.Dataset.-.December.2022.v3.csv">raw data</a>.</p>
+<p>Explore the <a href="https://github.com/github/government-open-source-policies/blob/main/data/OSS.Dataset.-.December.2022.v3.csv">raw data</a>.</p>
 <p>Run your own analysis by <a href="https://github.com/codespaces/new?hide_repo_select=true&amp;ref=main&amp;repo=github/government-open-source-policies">creating a Codespace</a> and opening the <a href="https://github.com/github/government-open-source-policies/blob/main/index.qmd">Quarto notebook</a> that powers the charts below.</p>
 <section id="using-quarto-in-codespaces" class="level3">
 <h3 class="anchored" data-anchor-id="using-quarto-in-codespaces">Using Quarto in Codespaces</h3>
@@ -1029,7 +1029,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
 <span id="cb23-34"><a href="#cb23-34" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb23-35"><a href="#cb23-35" aria-hidden="true" tabindex="-1"></a><span class="fu">## Dataset</span></span>
 <span id="cb23-36"><a href="#cb23-36" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb23-37"><a href="#cb23-37" aria-hidden="true" tabindex="-1"></a>Explore the <span class="co">[</span><span class="ot">raw data</span><span class="co">](https://github.com/github/government-open-source-policies-test/blob/main/data/OSS.Dataset.-.December.2022.v3.csv)</span>.</span>
+<span id="cb23-37"><a href="#cb23-37" aria-hidden="true" tabindex="-1"></a>Explore the <span class="co">[</span><span class="ot">raw data</span><span class="co">](https://github.com/github/government-open-source-policies/blob/main/data/OSS.Dataset.-.December.2022.v3.csv)</span>.</span>
 <span id="cb23-38"><a href="#cb23-38" aria-hidden="true" tabindex="-1"></a></span>
 <span id="cb23-39"><a href="#cb23-39" aria-hidden="true" tabindex="-1"></a>Run your own analysis by <span class="co">[</span><span class="ot">creating a Codespace</span><span class="co">](https://github.com/codespaces/new?hide_repo_select=true&amp;ref=main&amp;repo=github/government-open-source-policies)</span> and opening the <span class="co">[</span><span class="ot">Quarto notebook</span><span class="co">](https://github.com/github/government-open-source-policies/blob/main/index.qmd)</span> that powers the charts below.</span>
 <span id="cb23-40"><a href="#cb23-40" aria-hidden="true" tabindex="-1"></a></span>

--- a/index.qmd
+++ b/index.qmd
@@ -34,7 +34,7 @@ SOFTWARE.
 
 ## Dataset
 
-Explore the [raw data](https://github.com/github/government-open-source-policies-test/blob/main/data/OSS.Dataset.-.December.2022.v3.csv).
+Explore the [raw data](https://github.com/github/government-open-source-policies/blob/main/data/OSS.Dataset.-.December.2022.v3.csv).
 
 Run your own analysis by [creating a Codespace](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=github/government-open-source-policies) and opening the [Quarto notebook](https://github.com/github/government-open-source-policies/blob/main/index.qmd) that powers the charts below.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "government-open-source-policies-test",
+  "name": "government-open-source-policies",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -8,15 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/github/government-open-source-policies-test.git"
+    "url": "git+https://github.com/github/government-open-source-policies.git"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/github/government-open-source-policies-test/issues"
+    "url": "https://github.com/github/government-open-source-policies/issues"
   },
-  "homepage": "https://github.com/github/government-open-source-policies-test#readme",
+  "homepage": "https://github.com/github/government-open-source-policies#readme",
   "dependencies": {
     "datapackage": "^1.1.10"
   }


### PR DESCRIPTION
Fix links referring to https://github.com/github/government-open-source-policies-test URL

I noticed the issue when I was visiting this page:
https://github.github.io/government-open-source-policies/

I also see two links in docs/README.md that probably should be updated:
https://github.com/github/government-open-source-policies/blob/main/docs/README.md

```
You can explore summary visualizations of the dataset [here](https://reimagined-fortnight-b321a25c.pages.github.io/)
```
```
The dataset can also be accessed on the [CSIS website](#holder).
```